### PR TITLE
Let status bar been managed from the react-native side

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ import { getDeepLink } from './utilities'
 ...
 ```
 
+- StatusBar
+
+The StatusBar will keep the last one provided in your app. So if the StatusBar is `dark-content` before you open the browser this will keep it. If you want to change before opening you can do something like
+
+```javascript
+  async openInBrowser(url) {
+      try {
+        StatusBar.setBarStyle('dark-content')
+        await InAppBrowser.open(url)
+      } catch (error) {
+        Alert.alert(error.message);
+      }
+    }),
+```
+
 ## Credits 👍
 * **Expo:** [WebBrowser](https://docs.expo.io/versions/latest/sdk/webbrowser)
 * **React Native Custom Tabs:** [Chrome Custom Tabs for React Native](https://github.com/droibit/react-native-custom-tabs)

--- a/example/App.js
+++ b/example/App.js
@@ -7,7 +7,7 @@
  */
 
 import React, {Component} from 'react';
-import {Platform, StyleSheet, Text, View, Button, Alert, TextInput} from 'react-native';
+import {Platform, StyleSheet, Text, View, Button, Alert, TextInput, StatusBar} from 'react-native';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 
 const instructions = Platform.select({
@@ -30,6 +30,7 @@ export default class App extends Component {
   async openLink() {
     try {
       await InAppBrowser.isAvailable()
+      StatusBar.setBarStyle('light-content')
       InAppBrowser.open(this.state.url, {
         // iOS Properties
         dismissButtonStyle: 'cancel',
@@ -53,6 +54,7 @@ export default class App extends Component {
   render() {
     return (
       <View style={styles.container}>
+        <StatusBar barStyle="dark-content" />
         <Text style={styles.welcome}>{'Welcome InAppBrowser\nfor React Native!'}</Text>
         <Text style={styles.instructions}>Type the url</Text>
         <TextInput

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -194,13 +194,6 @@ RCT_EXPORT_METHOD(isAvailable:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromi
   _redirectReject = reject;
   _redirectResolve = resolve;
 
-  _initialStatusBarStyle = RCTSharedApplication().statusBarStyle;
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [RCTSharedApplication() setStatusBarStyle:UIStatusBarStyleDefault
-                                   animated:YES];
-#pragma clang diagnostic pop
   return YES;
 }
 
@@ -217,10 +210,6 @@ RCT_EXPORT_METHOD(isAvailable:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromi
 
 -(void)flowDidFinish
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [RCTSharedApplication() setStatusBarStyle:_initialStatusBarStyle animated:YES];
-#pragma clang diagnostic pop
   _redirectResolve = nil;
   _redirectReject = nil;
 }


### PR DESCRIPTION
This is for fixing issue #5 . With this change the status bar style can been manage from react native. This will keep the latest style from the app or you can example use the method for it. Example with the method.

```js
    openInBrowser: flow(function*() {
      try {
        StatusBar.setBarStyle('dark-content')
        yield WebBrowserServices.openUrl({ url: self.url });
      } catch (error) {
        Alert.alert(error.message);
      }
    }),
```