### PR TITLE
fix(docs): gradle compile config depreciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
   	```
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
   	```
-      compile project(':react-native-inappbrowser-reborn')
+      implementation project(':react-native-inappbrowser-reborn')
   	```
 
 ## Usage


### PR DESCRIPTION
PR facebook/react-native#20767 bumped the version of the Android
Gradle Plugin to v3 which uses the newer Gradle dependency
configurations `implementation` and `api` which make `compile`
obsolete.

PR facebook/react-native#20853 covered the `link` command.

Using `compile` will result in a warning message during app build and
`compile` will be eventually removed by Gradle.