### PR TITLE
supportLibVersion definition avoiding version collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@
   	```
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
   	```
-      implementation (project(':react-native-inappbrowser-reborn')){
-        exclude group: "com.android.support"
-      }
+      implementation project(':react-native-inappbrowser-reborn')
   	```
 
 ## Usage

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ def DEFAULT_COMPILE_SDK_VERSION = 27
 def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
 def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 27
+def DEFAULT_SUPPORT_LIB_VERSION = "27.1.1"
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -40,8 +41,8 @@ repositories {
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation 'com.facebook.react:react-native:+'
-  implementation "com.android.support:support-annotations:+"
-  implementation "com.android.support:customtabs:+"
+  implementation "com.android.support:support-annotations:safeExtGet('supportLibVersion', DEFAULT_SUPPORT_LIB_VERSION)"
+  implementation "com.android.support:customtabs:safeExtGet('supportLibVersion', DEFAULT_SUPPORT_LIB_VERSION)"
   implementation 'org.greenrobot:eventbus:3.+'
 }
   


### PR DESCRIPTION
Fixes many opened issues about support lib when building. Instead of excluding support lib packages and face another problems, change latest versions to sticky and configurable by main application.