### PR TITLE
[Flow] make all InAppBrowser.open() options optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,15 +14,15 @@ type BrowserResult = {
 };
 
 type InAppBrowserOptions = {
-  dismissButtonStyle: 'done' | 'close' | 'cancel',
-  preferredBarTintColor: string,
-  preferredControlTintColor: string,
-  toolbarColor: string,
-  enableUrlBarHiding: boolean,
-  showTitle: boolean,
-  enableDefaultShare: boolean,
-  forceCloseOnRedirection: boolean,
-  readerMode: boolean
+  dismissButtonStyle?: 'done' | 'close' | 'cancel',
+  preferredBarTintColor?: string,
+  preferredControlTintColor?: string,
+  toolbarColor?: string,
+  enableUrlBarHiding?: boolean,
+  showTitle?: boolean,
+  enableDefaultShare?: boolean,
+  forceCloseOnRedirection?: boolean,
+  readerMode?: boolean
 }
 
 async function open(url: string, options: InAppBrowserOptions = {}): Promise<BrowserResult.type> {


### PR DESCRIPTION
Currently all `InAppBrowser.open` options are mandatory in Flow, which raises a Flow error when any of them is missing. 
This is not correct, because any option has a default value and can be omitted. 
Also for TypeScript all options are considered optional, as stated in `index.d.ts`.