### PR TITLE
Fix the repository URL for podspec file

### DIFF
--- a/RNInAppBrowser.podspec
+++ b/RNInAppBrowser.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.source       = { :git => "https://github.com/author/RNInAppBrowser.git", :tag => "master" }
+  s.source       = { :git => package['repository']['url'], :tag => "master" }
 
   s.requires_arc   = true
   s.platform       = :ios, '8.0'


### PR DESCRIPTION
Updates a minor bug carried across from #10.

The URL of the repository is wrong - it now reads this from the `package.json` file instead of hard coding it.