### PR TITLE
Avoid crashes with iOS 9 for skipping preferredBarTintColor and preferredControlTintColor

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -111,11 +111,13 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
       safariVC.dismissButtonStyle = SFSafariViewControllerDismissButtonStyleCancel;
     }
   }
-  if (preferredBarTintColor) {
-    safariVC.preferredBarTintColor = [RCTConvert UIColor:preferredBarTintColor];
-  }
-  if (preferredControlTintColor) {
-    safariVC.preferredControlTintColor = [RCTConvert UIColor:preferredControlTintColor];
+  if (@available(iOS 10.0, *)) {
+    if (preferredBarTintColor) {
+      safariVC.preferredBarTintColor = [RCTConvert UIColor:preferredBarTintColor];
+    }
+    if (preferredControlTintColor) {
+      safariVC.preferredControlTintColor = [RCTConvert UIColor:preferredControlTintColor];
+    }
   }
 
  // By setting the modal presentation style to OverFullScreen, we disable the "Swipe to dismiss"


### PR DESCRIPTION
Options mentioned in PR topic are not supported with iOS 9.x and causes app crashing if set. That is just check that those will be skip with iOS 9.

https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller/2274394-preferredbartintcolor
https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller/2274393-preferredcontroltintcolor
