### PR TITLE
Fix peerDependency warning about react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/proyecto26/react-native-inappbrowser",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.55.0"
+    "react-native": ">=0.55.0"
   },
   "dependencies": {
     "invariant": "^2.2.4"


### PR DESCRIPTION
If react-native need to be as peerDependency, change it that if you don't use 0.55 which is quite old version, you don't get this  warn every time:

`npm WARN react-native-inappbrowser-reborn@1.3.12 requires a peer of react-native@^0.55.0 but none is installed. You must install peer dependencies yourself.`

For my testings, that works also without RN as peer dependency, or value as *, so I'm not sure if that needed at all here. But at least shouldn't warn users.