### PR TITLE
Fix typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module 'react-native-inappbrowser-reborn' {
       endEnter: string,
       endExit: string
     },
-    headers?: { [string]: string }
+    headers?: { [key: string]: string }
   }
 
   type AuthSessionResult = RedirectResult | BrowserResult;


### PR DESCRIPTION
Fixes this error:
```
node_modules/react-native-inappbrowser-reborn/index.d.ts:32:18 - error TS2693: 'string' only refers to a type, but is being used as a value here.
```