### PR TITLE
Fix EventBusException on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ StatusBar.setBarStyle = (style) => {
 };
 ```
 
-You can than restore the old bar style after the browser has been dismissed like this: 
+You can than restore the old bar style after the browser has been dismissed like this:
 
 ```javascript
   async openInBrowser(url) {
@@ -241,7 +241,7 @@ Thanks goes to these wonderful people:
 <!-- CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 | [<img alt="jdnichollsc" src="https://avatars3.githubusercontent.com/u/2154886?v=3" width="100" /><br /><sub><b>Juan Nicholls</b></sub>](https://github.com/jdnichollsc)<br />[✉](mailto:jdnichollsc@hotmail.com) | [<img alt="EQuimper" src="https://avatars3.githubusercontent.com/u/15819498?v=3" width="100" /><br /><sub><b>Emanuel Quimper</b></sub>](https://github.com/EQuimper)<br />[✉](mailto:quimperemanuel@gmail.com) | [<img alt="bonesyblue" src="https://avatars3.githubusercontent.com/u/7486722?v=3" width="100" /><br /><sub><b>Jonathan Bones</b></sub>](https://github.com/bonesyblue)<br />[✉](mailto:bonesyblue@gmail.com) | [<img alt="mlazari" src="https://avatars3.githubusercontent.com/u/4928274?v=3" width="100" /><br /><sub><b>Mihai Lazari</b></sub>](https://github.com/mlazari) | [<img alt="maestor" src="https://avatars3.githubusercontent.com/u/3604902?v=3" width="100" /><br /><sub><b>Kalle Haavisto</b></sub>](https://github.com/maestor)<br />[✉](mailto:maestori@gmail.com) | [<img alt="plamworapot" src="https://avatars3.githubusercontent.com/u/4770354?v=3" width="100" /><br /><sub><b>Worapot Pengsuk</b></sub>](https://github.com/plamworapot) | [<img alt="adammcarth" src="https://avatars3.githubusercontent.com/u/3016455?v=3" width="100" /><br /><sub><b>Adam McArthur</b></sub>](https://github.com/adammcarth)<br />[✉](mailto:adam@adammcarthur.net) |
 | :---: | :---: |:---: | :---: | :---: | :---: | :---: |
-| [<img alt="SnaiNeR" src="https://avatars3.githubusercontent.com/u/39980963?v=3" width="100" /><br /><sub><b>Artem Emelyanov</b></sub>](https://github.com/SnaiNeR)<br />[✉](mailto:snainer@gmail.com) | [<img alt="rbscott" src="https://avatars2.githubusercontent.com/u/882258?v=4&s=117" width="100" /><br /><sub><b>Robert Scott</b></sub>](https://github.com/rbscott) | [<img alt="Kikketer" src="https://avatars0.githubusercontent.com/u/958042?s=460&v=4" width="100" /><br /><sub><b>Chris Weed</b></sub>](https://github.com/kikketer) |
+| [<img alt="SnaiNeR" src="https://avatars3.githubusercontent.com/u/39980963?v=3" width="100" /><br /><sub><b>Artem Emelyanov</b></sub>](https://github.com/SnaiNeR)<br />[✉](mailto:snainer@gmail.com) | [<img alt="rbscott" src="https://avatars2.githubusercontent.com/u/882258?v=4&s=117" width="100" /><br /><sub><b>Robert Scott</b></sub>](https://github.com/rbscott) | [<img alt="Kikketer" src="https://avatars0.githubusercontent.com/u/958042?s=460&v=4" width="100" /><br /><sub><b>Chris Weed</b></sub>](https://github.com/kikketer) | [<img alt="almouro" src="https://avatars3.githubusercontent.com/u/4534323?v=4" width="100" /><br /><sub><b>Alexandre Moureaux</b></sub>](https://github.com/almouro) |
 <!-- CONTRIBUTORS-LIST:END -->
 
 ## Supporting 🍻

--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -134,7 +134,7 @@ public class RNInAppBrowser {
       intent.putExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE);
     }
 
-    EventBus.getDefault().register(this);
+    registerEventBus();
 
     currentActivity.startActivity(
         ChromeTabsManagerActivity.createStartIntent(currentActivity, intent));
@@ -144,14 +144,14 @@ public class RNInAppBrowser {
     if (mOpenBrowserPromise == null) {
       return;
     }
-    
+
     if (currentActivity == null) {
       mOpenBrowserPromise.reject(ERROR_CODE, "No activity");
       mOpenBrowserPromise = null;
       return;
     }
 
-    EventBus.getDefault().unregister(this);
+    registerEventBus();
 
     WritableMap result = Arguments.createMap();
     result.putString("type", "dismiss");
@@ -202,6 +202,12 @@ public class RNInAppBrowser {
       return context.getResources().getIdentifier(identifier, null, null);
     } else {
       return context.getResources().getIdentifier(identifier, "anim", context.getPackageName());
+    }
+  }
+
+  private void registerEventBus() {
+    if (!EventBus.getDefault().isRegistered(this)) {
+       EventBus.getDefault().register(this);
     }
   }
 }


### PR DESCRIPTION
Similar issue as https://github.com/proyecto26/react-native-inappbrowser/pull/45
Calling the `open` function twice could trigger the `EventBus.getDefault().register(this);` twice which would trigger:

```
org.greenrobot.eventbus.EventBusException: Subscriber class com.proyecto26.inappbrowser.RNInAppBrowser already registered to event
```

This makes sure we don't register again the browser instance