### PR TITLE
replace Assertation lib to AssertationError which already have

### DIFF
--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -11,7 +11,6 @@ import android.provider.Browser;
 import android.support.annotation.Nullable;
 import android.support.customtabs.CustomTabsIntent;
 
-import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.WritableMap;
@@ -165,7 +164,9 @@ public class RNInAppBrowser {
   public void onEvent(ChromeTabsDismissedEvent event) {
     EventBus.getDefault().unregister(this);
 
-    Assertions.assertNotNull(mOpenBrowserPromise);
+    if (mOpenBrowserPromise == null) {
+      throw new AssertionError();
+    }
 
     WritableMap result = Arguments.createMap();
     result.putString("type", event.resultType);


### PR DESCRIPTION
While build for Android, got this error:

> ### java compiler error
> error: package com.facebook.infer.annotation does not exist

We can replace Assertation library by using:

```
 if (mOpenBrowserPromise == null) {
      throw new AssertionError();
 }
```

like here:
https://github.com/facebook/infer/blob/master/infer/annotations/src/main/java/com/facebook/infer/annotation/Assertions.java#L24