### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,20 @@
 apply plugin: 'com.android.library'
 
 buildscript {
-  repositories {
-    maven { url "https://maven.google.com" }
-    jcenter()
-    google()
-  }
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            maven { url "https://maven.google.com" }
+            jcenter()
+            google()
+        }
 
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.1'
-  }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.5.1'
+        }
+    }
 }
 
 def safeExtGet(prop, fallback) {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip


### PR DESCRIPTION
Load Android Gradle Plugin conditionally. Also, upgraded Android Gradle Plugin and  Gradle wrapper version to the latest.

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)