### PR TITLE
Exclude unnecessary file and folders from release distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-.github/
 example/

--- a/android/.npmignore
+++ b/android/.npmignore
@@ -1,0 +1,10 @@
+*.iml
+.DS_Store
+.gradle/
+.idea/
+.npmignore
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties

--- a/ios/.npmignore
+++ b/ios/.npmignore
@@ -1,0 +1,6 @@
+*/project.xcworkspace/
+*/xcuserdata/
+.DS_Store
+.npmignore
+Pods/
+build/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "3.3.0",
   "description": "InAppBrowser for React Native",
   "main": "index.js",
+  "files": [
+    "android/",
+    "ios/",
+    "index.d.ts",
+    "RNInAppBrowser.podspec"
+  ],
   "readmeFilename": "README.md",
   "scripts": {
     "lint": "eslint index.js",


### PR DESCRIPTION
> all Gradle wrapper files need to be excluded from distribution

I already have the folder in my project that used this library as a dependency.

![image](https://user-images.githubusercontent.com/13766432/68654322-eb301a00-0542-11ea-9bc4-33b1aff69b8e.png)

so I add the folder into `.npmignore` to exclude it from release distributions.

you can take a look at the discussion on [this PR](https://github.com/kmagiera/react-native-reanimated/pull/463#issuecomment-552781215)

cc @friederbluemle