### PR TITLE
Disable swipe to dismiss gesture for modal

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -172,6 +172,9 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
       safariVC.preferredControlTintColor = [RCTConvert UIColor:preferredControlTintColor];
     }
   }
+  // To disable "Swipe to dismiss" gesture which sometimes causes a bug where `safariViewControllerDidFinish` 
+  // is not called.
+  safariVC.modalPresentationStyle = UIModalPresentationOverFullScreen;
 
   UIViewController *ctrl = RCTPresentedViewController();
   if (modalEnabled) {

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -172,9 +172,6 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
       safariVC.preferredControlTintColor = [RCTConvert UIColor:preferredControlTintColor];
     }
   }
-  // To disable "Swipe to dismiss" gesture which sometimes causes a bug where `safariViewControllerDidFinish` 
-  // is not called.
-  safariVC.modalPresentationStyle = UIModalPresentationOverFullScreen;
 
   UIViewController *ctrl = RCTPresentedViewController();
   if (modalEnabled) {
@@ -182,6 +179,9 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     UINavigationController *safariHackVC = [[UINavigationController alloc] initWithRootViewController:safariVC];
     [safariHackVC setNavigationBarHidden:true animated:false];
 
+    // To disable "Swipe to dismiss" gesture which sometimes causes a bug where `safariViewControllerDidFinish` 
+    // is not called.
+    safariVC.modalPresentationStyle = UIModalPresentationOverFullScreen;
     safariHackVC.modalPresentationStyle = [self getPresentationStyle: modalPresentationStyle];
     if(animated) {
       safariHackVC.modalTransitionStyle = [self getTransitionStyle: modalTransitionStyle];


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
https://github.com/proyecto26/react-native-inappbrowser/issues/131

## What is the new behavior?
Swipe to dismiss gesture is disabled for modal.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

