### PR TITLE
Supports ephemeralWebBrowserSession on iOS 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Property       | Description
 `modalTransitionStyle` (String)      | The transition style to use when presenting the view controller. [`coverVertical`/`flipHorizontal`/`crossDissolve`/`partialCurl`]
 `modalEnabled` (Boolean)             | Present the **SafariViewController** modally or as push instead. [`true`/`false`]
 `enableBarCollapsing` (Boolean)      | Determines whether the browser's tool bars will collapse or not. [`true`/`false`]
+`ephemeralWebSession` (Boolean)      | Prevent re-use cookies of previous session (openAuth only) [`true`/`false`]
 
 ### Android Options
 Property       | Description
@@ -296,6 +297,7 @@ import { getDeepLink } from './utilities'
         InAppBrowser.openAuth(url, deepLink, {
           // iOS Properties
           dismissButtonStyle: 'cancel',
+          ephemeralWebSession: false,
           // Android Properties
           showTitle: false,
           enableUrlBarHiding: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,8 @@ declare module 'react-native-inappbrowser-reborn' {
       | 'crossDissolve'
       | 'partialCurl',
     modalEnabled?: boolean,
-    enableBarCollapsing?: boolean
+    enableBarCollapsing?: boolean,
+    ephemeralWebSession?: boolean
   }
 
   type InAppBrowserAndroidOptions = {

--- a/index.js
+++ b/index.js
@@ -48,7 +48,8 @@ type InAppBrowseriOSOptions = {
     | 'crossDissolve'
     | 'partialCurl',
   modalEnabled?: boolean,
-  enableBarCollapsing?: boolean
+  enableBarCollapsing?: boolean,
+  ephemeralWebSession?: boolean
 };
 
 type InAppBrowserAndroidOptions = {

--- a/index.js
+++ b/index.js
@@ -103,10 +103,15 @@ async function openAuth(
   redirectUrl: string,
   options: InAppBrowserOptions = {}
 ): Promise<AuthSessionResult> {
+  const inAppBrowserOptions = {
+    ...options,
+    animated: options.ephemeralWebSession !== undefined ? options.ephemeralWebSession : false,
+  };
+
   if (_authSessionIsNativelySupported()) {
-    return RNInAppBrowser.openAuth(url, redirectUrl);
+    return RNInAppBrowser.openAuth(url, redirectUrl, inAppBrowserOptions);
   } else {
-    return _openAuthSessionPolyfillAsync(url, redirectUrl, options);
+    return _openAuthSessionPolyfillAsync(url, redirectUrl, inAppBrowserOptions);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ async function openAuth(
 ): Promise<AuthSessionResult> {
   const inAppBrowserOptions = {
     ...options,
-    animated: options.ephemeralWebSession !== undefined ? options.ephemeralWebSession : false,
+    ephemeralWebSession: options.ephemeralWebSession !== undefined ? options.ephemeralWebSession : false,
   };
 
   if (_authSessionIsNativelySupported()) {

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -92,6 +92,10 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
         initWithURL:url
         callbackURLScheme:redirectURL
         completionHandler:completionHandler];
+      
+      if (@available(iOS 13.0, *)) {
+        webAuthSession.prefersEphemeralWebBrowserSession = true;
+      }
     } else {
       authSession = [[SFAuthenticationSession alloc]
         initWithURL:url

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -59,6 +59,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
                   redirectURL:(NSString *)redirectURL
+                  options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -66,6 +67,8 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
     return;
   }
 
+  BOOL ephemeralWebSession = [options[@"ephemeralWebSession"] boolValue];
+    
   if (@available(iOS 11, *)) {
     NSURL *url = [[NSURL alloc] initWithString: authURL];
     __weak typeof(self) weakSelf = self;
@@ -93,7 +96,8 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
         callbackURLScheme:redirectURL
         completionHandler:completionHandler];
       
-      if (@available(iOS 13.0, *)) {
+      if (@available(iOS 13.0, *) && ephemeralWebSession) {
+        //Prevent re-use cookie from last auth session
         webAuthSession.prefersEphemeralWebBrowserSession = true;
       }
     } else {


### PR DESCRIPTION
Hello, 

Actually, on iOS 12+, when you login, the cookie is kept until the app is killed. 

Since iOS 13 it's possible to make session ephemeral. 
With this option prefersEphemeralWebBrowserSession, the cookie is killed when tab browser is closed. 

Pros : 
- no need to logout manualy users (for account switch for example) 
Cons : 
- user should reconnect each time the tab is presented.

It fix https://github.com/proyecto26/react-native-inappbrowser/issues/76 , on iOS 13.

TODO : Improvement : make this parameter as an option 

Best Regards

<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

