### PR TITLE
fixing mergeExtDexDebugAndroidTest task

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,10 @@ android {
   lintOptions {
     abortOnError false
   }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

running mergeExtDexDebugAndroidTest task failed. fixed it as described [here](https://stackoverflow.com/questions/49512629/default-interface-methods-are-only-supported-starting-with-android-n/49525685#49525685)

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Tried to run detox build for android in my project.
This library failed with:

```
> Transform artifact browser.aar (androidx.browser:browser:1.3.0-alpha01) with DexingTransform
AGPBI: {"kind":"error","text":"Static interface methods are only supported starting with Android N (--min-api 24): androidx.browser.trusted.TrustedWebActivityDisplayMode androidx.browser.trusted.TrustedWebActivityDisplayMode.fromBundle(android.os.Bundle)","sources":[{}],"tool":"D8"}

> Task :react-native-inappbrowser-reborn:mergeExtDexDebugAndroidTest FAILED
```


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->
Now I can run detox build in my root project and it doesn't fail.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

