### PR TITLE
Add a null check for redirectResolve in safariViewControllerDidFinish

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -286,9 +286,11 @@ RCT_EXPORT_METHOD(isAvailable:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromi
  */
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller
 {
-  redirectResolve(@{
-    @"type": @"cancel",
-  });
+  if (redirectResolve) {
+    redirectResolve(@{
+      @"type": @"cancel",
+    });
+  }
   [self flowDidFinish];
   if (!animated) {
     [self dismissWithoutAnimation:controller];


### PR DESCRIPTION
I am getting exception is this place and it seems like this check is done in many other places but here.

<img width="853" alt="Screenshot 2020-06-17 at 14 42 12" src="https://user-images.githubusercontent.com/1038270/84899369-def7d680-b0a8-11ea-8067-784195b0da23.png">
