### PR TITLE
fix(readme): update modalPresentationStyle to 'fullscreen'

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ import InAppBrowser from 'react-native-inappbrowser-reborn'
           preferredControlTintColor: 'white',
           readerMode: false,
           animated: true,
-          modalPresentationStyle: 'overFullScreen',
+          modalPresentationStyle: 'fullScreen',
           modalTransitionStyle: 'partialCurl',
           modalEnabled: true,
           enableBarCollapsing: false,
@@ -322,7 +322,7 @@ import { getDeepLink } from './utilities'
 ...
   async componentDidMount() {
     // Play Lottie Animation :)
-    
+
     // Validate the stored access token (Maybe with a request)
     // Redirect the user to the Home page if the token is still valid
     // Otherwise redirect to the Login page
@@ -342,7 +342,7 @@ import { getDeepLink } from './utilities'
       // Show error and redirect the user to the Login page
     }
   }
-  
+
   async loadUserInfo() {
     const { navigation } = this.props
     const { state: { params } } = navigation


### PR DESCRIPTION
fix(readme): update modalPresentationStyle to 'fullscreen' to fix use case of pasting code from readme and seeing native crash

<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
For my use case, pasting readme code into my project crashes immediately on attempting to open the browser

![Screen Shot 2020-06-24 at 6 22 58 PM](https://user-images.githubusercontent.com/15015324/85629613-91e7a780-b648-11ea-9068-408a3bb386f1.png)

found this: https://github.com/proyecto26/react-native-inappbrowser/issues/130#issuecomment-566569216

I'm not familiar with *why* only fullscreen is supported in my use case. It may or may not make sense to update readme. Sending PR as it is really small change with a big potential impact. Apparently prettier changed some whitespace too.

```
System:
    OS: macOS Mojave 10.14.6
    CPU: (8) x64 Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz
    Memory: 93.93 MB / 16.00 GB
    Shell: 5.0.17 - /usr/local/bin/bash
  Binaries:
    Node: 14.4.0 - ~/.nvm/versions/node/v14.4.0/bin/node
    Yarn: 1.22.4 - /usr/local/bin/yarn
    npm: 6.14.5 - ~/.nvm/versions/node/v14.4.0/bin/npm
    Watchman: 4.9.0 - /usr/local/bin/watchman
  Managers:
    CocoaPods: 1.9.3 - /usr/local/bin/pod
  SDKs:
    iOS SDK:
      Platforms: iOS 13.2, DriverKit 19.0, macOS 10.15, tvOS 13.2, watchOS 6.1
    Android SDK:
      API Levels: 21, 22, 24, 25, 26, 27, 28
      Build Tools: 23.0.1, 23.0.2, 26.0.1, 26.0.2, 26.0.3, 27.0.2, 27.0.3, 28.0.0, 28.0.3, 29.0.0, 29.0.1
      System Images: android-21 | Google APIs Intel x86 Atom_64, android-28 | Google APIs Intel x86 Atom, android-28 | Google APIs Intel x86 Atom_64
      Android NDK: Not Found
  IDEs:
    Android Studio: 3.4 AI-183.6156.11.34.5522156
    Xcode: 11.3.1/11C504 - /usr/bin/xcodebuild
  Languages:
    Java: 1.8.0_202-ea - /usr/bin/javac
    Python: 2.7.17 - /usr/local/bin/python
  npmPackages:
    @react-native-community/cli: Not Found
    react: 16.13.1 => 16.13.1
    react-native: 0.62.2 => 0.62.2
  npmGlobalPackages:
    *react-native*: Not Found
```

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

