### PR TITLE
add default browser for custom tab if any

### DIFF
--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -47,7 +47,10 @@ public class RNInAppBrowser {
   private static final String HASBACKBUTTON = "hasBackButton";
 
   private static final String ACTION_CUSTOM_TABS_CONNECTION = "android.support.customtabs.action.CustomTabsService";
-  private static final String CHROME_PACKAGE = "com.android.chrome";
+  private static final String CHROME_PACKAGE_STABLE = "com.android.chrome";
+  private static final String CHROME_PACKAGE_BETA = "com.chrome.beta";
+  private static final String CHROME_PACKAGE_DEV = "com.chrome.dev";
+  private static final String LOCAL_PACKAGE = "com.google.android.apps.chrome";
 
   private @Nullable Promise mOpenBrowserPromise;
   private Boolean isLightTheme;
@@ -192,7 +195,7 @@ public class RNInAppBrowser {
 
   private void setDefaultBrowser(Context context, Intent intent){
     List<ResolveInfo> resolveInfos = getPreferedPackages(context);
-    String packageName = CustomTabsClient.getPackageName(context, Arrays.asList(CHROME_PACKAGE));
+    String packageName = CustomTabsClient.getPackageName(context, Arrays.asList(CHROME_PACKAGE_STABLE, CHROME_PACKAGE_BETA, CHROME_PACKAGE_DEV, LOCAL_PACKAGE));
     if(packageName == null && resolveInfos != null && resolveInfos.size() > 0){
       packageName = resolveInfos.get(0).serviceInfo.packageName;
     }


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [ x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x ] All existing tests are passing
- [ x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A system popup will be shown if the device has installed multiple browsers or apps that can handle CustomTabsIntent service.

## What is the new behavior?
<!-- Describe the changes. -->
If Chrome is available, then Chrome is the highest priority browser selected, otherwise, the first browser which supports CustomTabsIntent is chosen.

Fixes #149 #107
Implements #86 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

