### PR TITLE
Fix Xcode 12 compatibility.

### DIFF
--- a/RNInAppBrowser.podspec
+++ b/RNInAppBrowser.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/**/*.{h,m}'
   s.exclude_files  = 'android/**/*'
 
-  s.dependency "React"
+  s.dependency "React-Core"
   #s.dependency "others"
 
 end


### PR DESCRIPTION
## What is the current behavior?
The iOS is depending on `React` Pod

## What is the new behavior?
This fixes the Xcode 12 compatibility issue. More info can be found here https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

This fixes #187 