### PR TITLE
Process colors in JS on Android

### DIFF
--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
-import android.graphics.Color;
 import android.graphics.BitmapFactory;
 import android.provider.Browser;
 import androidx.annotation.Nullable;
@@ -22,7 +21,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -80,25 +78,15 @@ public class RNInAppBrowser {
 
     CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
     if (options.hasKey(KEY_TOOLBAR_COLOR)) {
-      final String colorString = options.getString(KEY_TOOLBAR_COLOR);
-      try {
-        builder.setToolbarColor(Color.parseColor(colorString));
-        isLightTheme = toolbarIsLight(colorString);
-      } catch (IllegalArgumentException e) {
-        throw new JSApplicationIllegalArgumentException(
-                "Invalid toolbar color '" + colorString + "': " + e.getMessage());
-      }
+      final int color = options.getInt(KEY_TOOLBAR_COLOR);
+      builder.setToolbarColor(color);
+      isLightTheme = toolbarIsLight(color);
     }
     if (options.hasKey(KEY_SECONDARY_TOOLBAR_COLOR)) {
-      final String colorString = options.getString(KEY_SECONDARY_TOOLBAR_COLOR);
-      try {
-        builder.setSecondaryToolbarColor(Color.parseColor(colorString));
-      } catch (IllegalArgumentException e) {
-        throw new JSApplicationIllegalArgumentException(
-                "Invalid secondary toolbar color '" + colorString + "': " + e.getMessage());
-      }
+      final int color = options.getInt(KEY_SECONDARY_TOOLBAR_COLOR);
+      builder.setSecondaryToolbarColor(color);
     }
-    if (options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM) && 
+    if (options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM) &&
         options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)) {
       builder.addDefaultShareMenuItem();
     }
@@ -151,7 +139,7 @@ public class RNInAppBrowser {
     }
 
     intent.putExtra(CustomTabsIntent.EXTRA_ENABLE_URLBAR_HIDING, (
-      options.hasKey(KEY_ENABLE_URL_BAR_HIDING) && 
+      options.hasKey(KEY_ENABLE_URL_BAR_HIDING) &&
       options.getBoolean(KEY_ENABLE_URL_BAR_HIDING)));
     try {
       if (options.hasKey(KEY_BROWSER_PACKAGE)) {
@@ -166,7 +154,7 @@ public class RNInAppBrowser {
     } catch (Exception e) {
       e.printStackTrace();
     }
-    
+
     intent.setData(Uri.parse(url));
     if (options.hasKey(KEY_SHOW_PAGE_TITLE)) {
       builder.setShowTitle(options.getBoolean(KEY_SHOW_PAGE_TITLE));
@@ -266,8 +254,8 @@ public class RNInAppBrowser {
     }
   }
 
-  private Boolean toolbarIsLight(String themeColor) {
-    return ColorUtils.calculateLuminance(Color.parseColor(themeColor)) > 0.5;
+  private Boolean toolbarIsLight(int themeColor) {
+    return ColorUtils.calculateLuminance(themeColor) > 0.5;
   }
 
   private List<ResolveInfo> getPreferredPackages(Context context) {

--- a/types.js
+++ b/types.js
@@ -62,6 +62,9 @@ type InAppBrowserAndroidOptions = {
   showInRecents?: boolean,
 };
 
-export type InAppBrowserOptions = InAppBrowserAndroidOptions | InAppBrowseriOSOptions;
+export type InAppBrowserOptions = {
+  ...InAppBrowserAndroidOptions,
+  ...InAppBrowseriOSOptions
+};
 
 export type AuthSessionResult = RedirectResult | BrowserResult;

--- a/utils.js
+++ b/utils.js
@@ -75,6 +75,14 @@ async function checkResultAndReturnUrl(
   }
 }
 
+function maybeProcessColor(color?: string | number) {
+  if (color == null || typeof color === 'number') {
+    return color;
+  } else {
+    return processColor(color);
+  }
+}
+
 export async function openBrowserAsync(
   url: string,
   options?: InAppBrowserOptions = {
@@ -88,12 +96,12 @@ export async function openBrowserAsync(
   return RNInAppBrowser.open({
     ...options,
     url,
-    preferredBarTintColor:
-      options.preferredBarTintColor &&
-      processColor(options.preferredBarTintColor),
-    preferredControlTintColor:
-      options.preferredControlTintColor &&
-      processColor(options.preferredControlTintColor)
+    preferredBarTintColor: maybeProcessColor(options.preferredBarTintColor),
+    preferredControlTintColor: maybeProcessColor(
+      options.preferredControlTintColor
+    ),
+    toolbarColor: maybeProcessColor(options.toolbarColor),
+    secondaryToolbarColor: maybeProcessColor(options.secondaryToolbarColor)
   })
 }
 


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently colors are processed differently on iOS and Android so it doesn't support the same values. For example rgba(...) is not supported.

## What is the new behavior?
<!-- Describe the changes. -->

Use `processColor` in JS to support all formats that RN supports for colors, this is what is used for iOS already. It also moves options processing to a function to be able to reuse it, we didn't process options for the openAuth method.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

