### PR TITLE
Release 3.5.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
+.github/
 example/
+img/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ in case of vulnerabilities.
 
 ## [Unreleased]
 
+## [3.5.1] - 2020-10-16
+
+### Fixed
+
+- Removed `files` option from **package.json** to use `.npmignore` instead.
+- Added `hasBackButton` to **index.d.ts** for typescript by [@sharifhh](https://github.com/sharifhh) ([#200](https://github.com/proyecto26/react-native-inappbrowser/pull/200)).
+
 ## [3.5.0] - 2020-10-16
 
 ### Added
@@ -168,7 +175,8 @@ Missing tags for previous versions 🤷‍♂
 - Fix `EventBusException` on **Android** by [@Almouro](https://github.com/Almouro) ([9cf4cbb](https://github.com/proyecto26/react-native-inappbrowser/commit/9cf4cbb58d55c8b534dabac6791e6a2a5428253f)).
 
 
-[Unreleased]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.5.1...HEAD
+[3.5.1]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.3.4...v3.4.0
 [3.3.4]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.3.3...v3.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ in case of vulnerabilities.
 
 ## [Unreleased]
 
-## [3.5.0] - 2020-10-14
+## [3.5.0] - 2020-10-16
 
 ### Added
 - Added `hasBackButton` option to sets a back arrow instead of the default X icon to close the custom tab by [@aitorct](https://github.com/aitorct) ([#109](https://github.com/proyecto26/react-native-inappbrowser/pull/109)).
@@ -169,7 +169,7 @@ Missing tags for previous versions 🤷‍♂
 
 
 [Unreleased]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.5.0...HEAD
-[3.4.0]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.4.0...v3.5.0
+[3.5.0]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.3.4...v3.4.0
 [3.3.4]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.3.3...v3.3.4
 [3.3.3]: https://github.com/proyecto26/react-native-inappbrowser/compare/v3.3.2...v3.3.3

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 <h4 align="center"><a href="https://developer.chrome.com/multidevice/android/customtabs#whatarethey">Chrome Custom Tabs</a> for Android & <a href="https://developer.apple.com/documentation/safariservices">SafariServices</a>/<a href="https://developer.apple.com/documentation/authenticationservices">AuthenticationServices</a> for iOS.</h4>
 
 <p align="center">
-  <img width="400px" src="img/inappbrowser.png">
+  <img width="400px" src="https://github.com/proyecto26/react-native-inappbrowser/blob/main/img/inappbrowser.png?raw=true">
 </p>
 
 ## Getting started

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,7 @@ declare module 'react-native-inappbrowser-reborn' {
       endExit: string
     },
     headers?: { [key: string]: string },
+    hasBackButton?: boolean,
     browserPackage?: string,
     showInRecents?: boolean
   }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,6 @@
   "version": "3.5.0",
   "description": "InAppBrowser for React Native",
   "main": "index.js",
-  "files": [
-    "android/",
-    "ios/",
-    "index.d.ts",
-    "RNInAppBrowser.podspec"
-  ],
   "scripts": {
     "flow": "flow check",
     "lint": "eslint index.js",


### PR DESCRIPTION
### Fixed

- Removed `files` option from **package.json** to use `.npmignore` instead.
- Added `hasBackButton` to **index.d.ts** for typescript by [@sharifhh](https://github.com/sharifhh) ([#200](https://github.com/proyecto26/react-native-inappbrowser/pull/200)).