### PR TITLE
Add try catch block to Safari View Controller logic

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -155,7 +155,14 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     SFSafariViewControllerConfiguration *config = [[SFSafariViewControllerConfiguration alloc] init];
     config.barCollapsingEnabled = enableBarCollapsing;
     config.entersReaderIfAvailable = readerMode;
-    safariVC = [[SFSafariViewController alloc] initWithURL:url configuration:config];
+    @try {
+      safariVC = [[SFSafariViewController alloc] initWithURL:url configuration:config];
+    }
+    @catch (NSException *exception) {
+      reject(RNInAppBrowserErrorCode, @"Unable to open url.", nil);
+      [self _close];
+      return;
+    }
   } else {
     safariVC = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
   }


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Malformed urls is causing the app to crash since the Safari View Controller does not work with all urls. 


## What is the new behavior?
<!-- Describe the changes. -->
Fixes/Implements/Closes #189.

Based on the description okwast gives [here](https://github.com/proyecto26/react-native-inappbrowser/issues/189) a try catch block is added around the initialization of the SFSafariViewController.

With this change exceptions thrown by the native layer can be handled at the react native layer.  



