### PR TITLE
Makes sure the SFSavariViewController view get's loaded before presenting it

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -205,6 +205,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     [ctrl presentViewController:safariHackVC animated:animated completion:nil];
   }
   else {
+    ctrl.view; // loads the view if not loaded yet (https://stackoverflow.com/a/57289613/1658268)
     [ctrl presentViewController:safariVC animated:animated completion:nil];
   }
 }


### PR DESCRIPTION
Makes sure the SFSavariViewController view get's loaded before presenting it

https://stackoverflow.com/a/57289613/1658268

The reason this works is explained here: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621460-view

> If you access this property and its value is currently nil, the view controller automatically calls the loadView() method and returns the resulting view.

Fix for: https://github.com/proyecto26/react-native-inappbrowser/issues/222