### PR TITLE
#186 openAuth crashed when going to be closed and then press the cancel button

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -79,13 +79,13 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
           if (!error) {
             NSString *url = callbackURL.absoluteString;
             redirectResolve(@{
-                @"type" : @"success",
-                  @"url" : url,
-                  });
+              @"type" : @"success",
+              @"url" : url,
+            });
           } else {
             redirectResolve(@{
-                @"type" : @"cancel",
-                  });
+              @"type" : @"cancel",
+            });
           }
         }
         [strongSelf flowDidFinish];

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -75,16 +75,18 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
     void (^completionHandler)(NSURL * _Nullable, NSError *_Nullable) = ^(NSURL* _Nullable callbackURL, NSError* _Nullable error) {
       __strong typeof(weakSelf) strongSelf = weakSelf;
       if (strongSelf) {
-        if (!error) {
-          NSString *url = callbackURL.absoluteString;
-          redirectResolve(@{
-            @"type" : @"success",
-            @"url" : url,
-          });
-        } else {
-          redirectResolve(@{
-            @"type" : @"cancel",
-          });
+        if (redirectResolve) {
+          if (!error) {
+            NSString *url = callbackURL.absoluteString;
+            redirectResolve(@{
+                @"type" : @"success",
+                  @"url" : url,
+                  });
+          } else {
+            redirectResolve(@{
+                @"type" : @"cancel",
+                  });
+          }
         }
         [strongSelf flowDidFinish];
       }


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

openAuth crashed when going to be closed and then press the cancel button.

The completionHandler was called, then redirectResolve to be null by flowDidFinish. After that completionHandler be call again by press the cancel button.

redirectResolve is null, and so crash.

## What is the new behavior?
<!-- Describe the changes. -->

No more crash.

Fixes/Implements/Closes #186.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

