### PR TITLE
fix(flow) - Make InAppBrowserOptions exact typed

### DIFF
--- a/types.js
+++ b/types.js
@@ -3,20 +3,20 @@
  * @flow strict-local
  */
 
-export type RedirectEvent = {
+export type RedirectEvent = {|
   url: 'string',
-};
+|};
 
-export type BrowserResult = {
+export type BrowserResult = {|
   type: 'cancel' | 'dismiss',
-};
+|};
 
-export type RedirectResult = {
+export type RedirectResult = {|
   type: 'success',
   url: string,
-};
+|};
 
-type InAppBrowseriOSOptions = {
+type InAppBrowseriOSOptions = {|
   dismissButtonStyle?: 'done' | 'close' | 'cancel',
   preferredBarTintColor?: string,
   preferredControlTintColor?: string,
@@ -41,9 +41,9 @@ type InAppBrowseriOSOptions = {
   modalEnabled?: boolean,
   enableBarCollapsing?: boolean,
   ephemeralWebSession?: boolean,
-};
+|};
 
-type InAppBrowserAndroidOptions = {
+type InAppBrowserAndroidOptions = {|
   showTitle?: boolean,
   toolbarColor?: string,
   secondaryToolbarColor?: string,
@@ -60,11 +60,8 @@ type InAppBrowserAndroidOptions = {
   hasBackButton?: boolean,
   browserPackage?: string,
   showInRecents?: boolean,
-};
+|};
 
-export type InAppBrowserOptions = {
-  ...InAppBrowserAndroidOptions,
-  ...InAppBrowseriOSOptions
-};
+export type InAppBrowserOptions = InAppBrowserAndroidOptions | InAppBrowseriOSOptions;
 
 export type AuthSessionResult = RedirectResult | BrowserResult;


### PR DESCRIPTION
Flow are complaining about the exact types, this small PR should fix this issue
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/react-native-inappbrowser-reborn/types.js:65:35

Flow cannot determine a type for InAppBrowserOptions [1]. InAppBrowseriOSOptions [2] is inexact, so it may contain
toolbarColor with a type that conflicts with toolbarColor's definition in InAppBrowserAndroidOptions [3]. Can you make
InAppBrowseriOSOptions [2] exact?.

     62│   showInRecents?: boolean,
     63│ };
     64│
 [1] 65│ export type InAppBrowserOptions = {
 [3] 66│   ...InAppBrowserAndroidOptions,
 [2] 67│   ...InAppBrowseriOSOptions
     68│ };
     69│
     70│ export type AuthSessionResult = RedirectResult | BrowserResult;
     71│

```

<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/master/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

