### PR TITLE
fix(android): 279 - Fix error cannot find symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ in case of vulnerabilities.
 
 ## [Unreleased]
 
+### Fixed
+- Fix `Build failed. Error cannot find symbol builder.setNavigationBarColor` error for Android Support ([#281](https://github.com/proyecto26/react-native-inappbrowser/pull/281)).
+
 ## [3.6.1] - 2021-06-27
 
 ### Added

--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -64,11 +64,10 @@ public class RNInAppBrowser {
   private static final Pattern animationIdentifierPattern = Pattern.compile("^.+:.+/");
 
   public Integer setColor(CustomTabsIntent.Builder builder, final ReadableMap options, String key, String method, String colorName) {
-    String colorString = "";
+    String colorString = options.getString(key);
     Integer color = null;
     try {
-      if (options.hasKey(key)) {
-        colorString = options.getString(key);
+      if (colorString != null) {
         color = Color.parseColor(colorString);
         Method findMethod = builder.getClass().getDeclaredMethod(method, int.class);
         findMethod.invoke(builder, color);

--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -103,9 +103,9 @@ public class RNInAppBrowser {
 
     CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
     isLightTheme = false;
-    final Integer toolBarColor = setColor(builder, options, KEY_TOOLBAR_COLOR, "setToolbarColor", "toolbar");
-    if (toolBarColor != null) {
-      isLightTheme = toolbarIsLight(toolBarColor);
+    final Integer toolbarColor = setColor(builder, options, KEY_TOOLBAR_COLOR, "setToolbarColor", "toolbar");
+    if (toolbarColor != null) {
+      isLightTheme = toolbarIsLight(toolbarColor);
     }
     setColor(builder, options, KEY_SECONDARY_TOOLBAR_COLOR, "setSecondaryToolbarColor", "secondary toolbar");
     setColor(builder, options, KEY_NAVIGATION_BAR_COLOR, "setNavigationBarColor", "navigation bar");

--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -27,6 +27,7 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.List;
@@ -61,6 +62,33 @@ public class RNInAppBrowser {
   private Boolean isLightTheme;
   private Activity currentActivity;
   private static final Pattern animationIdentifierPattern = Pattern.compile("^.+:.+/");
+
+  public void setNavigationColors(CustomTabsIntent.Builder builder, final ReadableMap options) {
+    if (options.hasKey(KEY_NAVIGATION_BAR_COLOR)) {
+      final String colorString = options.getString(KEY_NAVIGATION_BAR_COLOR);
+      try {
+        Method setNavigationBarColor = builder.getClass().getDeclaredMethod("setNavigationBarColor", int.class);
+        setNavigationBarColor.invoke(builder, Color.parseColor(colorString));
+      } catch (Exception e) {
+        if (e instanceof IllegalArgumentException) {
+          throw new JSApplicationIllegalArgumentException(
+                  "Invalid navigation bar color '" + colorString + "': " + e.getMessage());
+        }
+      }
+    }
+    if (options.hasKey(KEY_NAVIGATION_BAR_DIVIDER_COLOR)) {
+      final String colorString = options.getString(KEY_NAVIGATION_BAR_DIVIDER_COLOR);
+      try {
+        Method setNavigationBarDividerColor = builder.getClass().getDeclaredMethod("setNavigationBarDividerColor", int.class);
+        setNavigationBarDividerColor.invoke(builder, Color.parseColor(colorString));
+      } catch (Exception e) {
+        if (e instanceof IllegalArgumentException) {
+          throw new JSApplicationIllegalArgumentException(
+                "Invalid navigation bar divider color '" + colorString + "': " + e.getMessage());
+        }
+      }
+    }
+  }
 
   public void open(Context context, final ReadableMap options, final Promise promise, Activity activity) {
     final String url = options.getString("url");
@@ -101,24 +129,8 @@ public class RNInAppBrowser {
                 "Invalid secondary toolbar color '" + colorString + "': " + e.getMessage());
       }
     }
-    if (options.hasKey(KEY_NAVIGATION_BAR_COLOR)) {
-      final String colorString = options.getString(KEY_NAVIGATION_BAR_COLOR);
-      try {
-        builder.setNavigationBarColor(Color.parseColor(colorString));
-      } catch (IllegalArgumentException e) {
-        throw new JSApplicationIllegalArgumentException(
-                "Invalid navigation bar color '" + colorString + "': " + e.getMessage());
-      }
-    }
-    if (options.hasKey(KEY_NAVIGATION_BAR_DIVIDER_COLOR)) {
-      final String colorString = options.getString(KEY_NAVIGATION_BAR_DIVIDER_COLOR);
-      try {
-        builder.setNavigationBarDividerColor(Color.parseColor(colorString));
-      } catch (IllegalArgumentException e) {
-        throw new JSApplicationIllegalArgumentException(
-                "Invalid navigation bar divider color '" + colorString + "': " + e.getMessage());
-      }
-    }
+    setNavigationColors(builder, options);
+
     if (options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM) && 
         options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)) {
       builder.addDefaultShareMenuItem();


### PR DESCRIPTION
Fix `Build failed. Error cannot find symbol builder.setNavigationBarColor` error for Android Support

<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Android Support is not working with the new methods of `CustomTabsIntent.Builder` for `AndroidX`.

## What is the new behavior?
<!-- Describe the changes. -->
Detect if the method exists before to invoke the function to avoid build issues by using Reflection.

Fixes/Implements/Closes #279.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

