### PR TITLE
Prevent iOS crash when redirect url is null

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -90,7 +90,10 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
       }
     };
 
-    NSString *escapedRedirectURL = [[NSURL alloc] initWithString:redirectURL].scheme;
+    NSString *escapedRedirectURL = nil;
+    if (redirectURL) {
+        escapedRedirectURL = [[NSURL alloc] initWithString:redirectURL].scheme;
+    }
 
     if (@available(iOS 12.0, *)) {
       webAuthSession = [[ASWebAuthenticationSession alloc]


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
On iOS, calling `openAuth` with undefined/null for `redirectUrl` will crash the app. This issue was recently introduced in [this commit](https://github.com/proyecto26/react-native-inappbrowser/commit/b35ef11f48c072971ec61049dc1370678db2dac1#diff-4ad743dcf362c4be43c8798f2c973b620a77dfabbd789c60f4574a416dcd03b8) where the scheme is being extracted from the redirect url. The result is that `escapedRedirectURL = "<null>"` which is not a valid URL scheme.

```
ExceptionsManager.js:179 Exception '*** -[NSURL initWithString:relativeToURL:]: nil string parameter' was thrown while invoking openAuth on target RNInAppBrowser with params (
    "https://xxx.xxx.amazoncognito.com/logout?client_id=xxx&logout_uri=myscheme%3A%2F%2Fpath",
    "<null>",
       ...
```

## What is the new behavior?
Don't attempt to extract the scheme from `redirectUrl` if it is undefined. Simply pass in `nil` which will be handled gracefully.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

