### PR TITLE
Replaces deprecated Android addDefaultShareMenuItem with setShareState

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Property       | Description
 `navigationBarColor` (String)     | Sets the navigation bar color. [`gray`/`#808080`]
 `navigationBarDividerColor` (String) | Sets the navigation bar divider color.  [`white`/`#FFFFFF`]
 `enableUrlBarHiding` (Boolean)    | Enables the url bar to hide as the user scrolls down on the page. [`true`/`false`]
-`enableDefaultShare` (Boolean)    | Adds a default share item to the menu. [`true`/`false`]
+`enableShareState` (Boolean)      | Sets the share item in the toolbar. Browser default will be used if this is not set. [`true`/`false`]
 `animations` (Object)             | Sets the start and exit animations. [`{ startEnter, startExit, endEnter, endExit }`]
 `headers` (Object)                | The data are key/value pairs, they will be sent in the HTTP request headers for the provided url. [`{ 'Authorization': 'Bearer ...' }`]
 `forceCloseOnRedirection` (Boolean) | Open Custom Tab in a new task to avoid issues redirecting back to app scheme. [`true`/`false`]
@@ -205,7 +205,7 @@ import { InAppBrowser } from 'react-native-inappbrowser-reborn'
           navigationBarColor: 'black',
           navigationBarDividerColor: 'white',
           enableUrlBarHiding: true,
-          enableDefaultShare: true,
+          enableShareState: true,
           forceCloseOnRedirection: false,
           // Specify full animation resource identifier(package:anim/name)
           // or only resource name(in case of animation bundled with app).
@@ -324,7 +324,7 @@ import { getDeepLink } from './utilities'
           // Android Properties
           showTitle: false,
           enableUrlBarHiding: true,
-          enableDefaultShare: false
+          enableShareState: false
         }).then((response) => {
           if (
             response.type === 'success' &&

--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -40,7 +40,7 @@ public class RNInAppBrowser {
   private static final String KEY_NAVIGATION_BAR_DIVIDER_COLOR = "navigationBarDividerColor";
   private static final String KEY_ENABLE_URL_BAR_HIDING = "enableUrlBarHiding";
   private static final String KEY_SHOW_PAGE_TITLE = "showTitle";
-  private static final String KEY_DEFAULT_SHARE_MENU_ITEM = "enableDefaultShare";
+  private static final String KEY_ENABLE_SHARE_STATE = "enableShareState";
   private static final String KEY_FORCE_CLOSE_ON_REDIRECTION = "forceCloseOnRedirection";
   private static final String KEY_ANIMATIONS = "animations";
   private static final String KEY_HEADERS = "headers";
@@ -111,9 +111,10 @@ public class RNInAppBrowser {
     setColor(builder, options, KEY_NAVIGATION_BAR_COLOR, "setNavigationBarColor", "navigation bar");
     setColor(builder, options, KEY_NAVIGATION_BAR_DIVIDER_COLOR, "setNavigationBarDividerColor", "navigation bar divider");
 
-    if (options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM) && 
-        options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)) {
-      builder.addDefaultShareMenuItem();
+    if (options.hasKey(KEY_ENABLE_SHARE_STATE)) {
+      builder.setShareState(
+        options.getBoolean(KEY_ENABLE_SHARE_STATE) ? CustomTabsIntent.SHARE_STATE_ON : CustomTabsIntent.SHARE_STATE_OFF
+      );
     }
     if (options.hasKey(KEY_ANIMATIONS)) {
       final ReadableMap animations = options.getMap(KEY_ANIMATIONS);


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
The Android option `enableDefaultShare` uses a deprecated method [setDefaultShareMenuItemEnabled](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder#setDefaultShareMenuItemEnabled(boolean)) on CustomTabsIntent.

It is not possible to disable the share button with the current option.


## What is the new behavior?
This PR replaces the `enableDefaultShare` option with a new `enableShareState` option that uses the new [setShareState](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder#setShareState(int)) method.

This allows the share button in the toolbar to be enabled or disabled.


BREAKING CHANGES:
`enableDefaultShare` option changed to `enableShareState`

