### PR TITLE
iOS: Add formSheetPreferredContentSize prop to allow for custom sized formSheet modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ in case of vulnerabilities.
 
 ## [Unreleased]
 
+## [3.7.0] - 2022-03-01
+
+### Added
+- iOS: Add formSheetPreferredContentSize prop to allow for custom sized formSheet modals by [@ShaneMckenna23](https://github.com/ShaneMckenna23) ([#331](https://github.com/proyecto26/react-native-inappbrowser/pull/331)).
+
 ## [3.6.3] - 2021-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Property       | Description
 `modalEnabled` (Boolean)             | Present the **SafariViewController** modally or as push instead. [`true`/`false`]
 `enableBarCollapsing` (Boolean)      | Determines whether the browser's tool bars will collapse or not. [`true`/`false`]
 `ephemeralWebSession` (Boolean)      | Prevent re-use cookies of previous session (openAuth only) [`true`/`false`]
-`formSheetContentSize` (Object)      | Custom size for `formSheet` modals [`{width: 400, height: 500}`]
+`formSheetPreferredContentSize` (Object)      | Custom size for `formSheet` modals [`{width: 400, height: 500}`]
 
 ### Android Options
 Property       | Description

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Property       | Description
 `modalEnabled` (Boolean)             | Present the **SafariViewController** modally or as push instead. [`true`/`false`]
 `enableBarCollapsing` (Boolean)      | Determines whether the browser's tool bars will collapse or not. [`true`/`false`]
 `ephemeralWebSession` (Boolean)      | Prevent re-use cookies of previous session (openAuth only) [`true`/`false`]
+`formSheetContentSize` (Object)      | Custom size for `formSheet` modals [`{width: 400, height: 500}`]
 
 ### Android Options
 Property       | Description

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Property       | Description
 `modalEnabled` (Boolean)             | Present the **SafariViewController** modally or as push instead. [`true`/`false`]
 `enableBarCollapsing` (Boolean)      | Determines whether the browser's tool bars will collapse or not. [`true`/`false`]
 `ephemeralWebSession` (Boolean)      | Prevent re-use cookies of previous session (openAuth only) [`true`/`false`]
-`formSheetPreferredContentSize` (Object)      | Custom size for `formSheet` modals [`{width: 400, height: 500}`]
+`formSheetPreferredContentSize` (Object)      | Custom size for iPad `formSheet` modals [`{width: 400, height: 500}`]
 
 ### Android Options
 Property       | Description

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,8 @@ declare module 'react-native-inappbrowser-reborn' {
       | 'partialCurl',
     modalEnabled?: boolean,
     enableBarCollapsing?: boolean,
-    ephemeralWebSession?: boolean
+    ephemeralWebSession?: boolean,
+    formSheetContentSize?: { width: number, height: number },
   }
 
   export type InAppBrowserAndroidOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module 'react-native-inappbrowser-reborn' {
     modalEnabled?: boolean,
     enableBarCollapsing?: boolean,
     ephemeralWebSession?: boolean,
-    formSheetContentSize?: { width: number, height: number },
+    formSheetPreferredContentSize?: { width: number, height: number },
   }
 
   export type InAppBrowserAndroidOptions = {

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -148,6 +148,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
   NSNumber* preferredControlTintColor = [options valueForKey:@"preferredControlTintColor"];
   NSString* modalPresentationStyle = [options valueForKey:@"modalPresentationStyle"];
   NSString* modalTransitionStyle = [options valueForKey:@"modalTransitionStyle"];
+  NSDictionary* formSheetContentSize = [options valueForKey:@"formSheetContentSize"];
 
   BOOL readerMode = [options[@"readerMode"] boolValue];
   BOOL enableBarCollapsing = [options[@"enableBarCollapsing"] boolValue];
@@ -207,6 +208,16 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
     if(animated) {
       safariHackVC.modalTransitionStyle = [self getTransitionStyle: modalTransitionStyle];
     }
+      
+    if([modalPresentationStyle isEqualToString:@"formSheet"] && formSheetContentSize){
+      NSNumber *width = [formSheetContentSize valueForKey:@"width"];
+      NSNumber *height = [formSheetContentSize valueForKey:@"height"];
+      
+      if(width && height){
+        safariHackVC.preferredContentSize = CGSizeMake([width doubleValue], [height doubleValue]);
+      }
+    }
+    
     safariHackVC.presentationController.delegate = self;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"

--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -148,7 +148,7 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
   NSNumber* preferredControlTintColor = [options valueForKey:@"preferredControlTintColor"];
   NSString* modalPresentationStyle = [options valueForKey:@"modalPresentationStyle"];
   NSString* modalTransitionStyle = [options valueForKey:@"modalTransitionStyle"];
-  NSDictionary* formSheetContentSize = [options valueForKey:@"formSheetContentSize"];
+  NSDictionary* formSheetPreferredContentSize = [options valueForKey:@"formSheetPreferredContentSize"];
 
   BOOL readerMode = [options[@"readerMode"] boolValue];
   BOOL enableBarCollapsing = [options[@"enableBarCollapsing"] boolValue];
@@ -209,9 +209,9 @@ RCT_EXPORT_METHOD(open:(NSDictionary *)options
       safariHackVC.modalTransitionStyle = [self getTransitionStyle: modalTransitionStyle];
     }
       
-    if([modalPresentationStyle isEqualToString:@"formSheet"] && formSheetContentSize){
-      NSNumber *width = [formSheetContentSize valueForKey:@"width"];
-      NSNumber *height = [formSheetContentSize valueForKey:@"height"];
+    if([modalPresentationStyle isEqualToString:@"formSheet"] && formSheetPreferredContentSize){
+      NSNumber *width = [formSheetPreferredContentSize valueForKey:@"width"];
+      NSNumber *height = [formSheetPreferredContentSize valueForKey:@"height"];
       
       if(width && height){
         safariHackVC.preferredContentSize = CGSizeMake([width doubleValue], [height doubleValue]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-inappbrowser-reborn",
-  "version": "3.6.3",
+  "version": "3.7.0",
   "description": "InAppBrowser for React Native",
   "main": "index.js",
   "scripts": {

--- a/types.js
+++ b/types.js
@@ -41,6 +41,7 @@ export type InAppBrowseriOSOptions = {|
   modalEnabled?: boolean,
   enableBarCollapsing?: boolean,
   ephemeralWebSession?: boolean,
+  formSheetContentSize?: { width: number, height: number },
 |};
 
 export type InAppBrowserAndroidOptions = {|

--- a/types.js
+++ b/types.js
@@ -41,7 +41,7 @@ export type InAppBrowseriOSOptions = {|
   modalEnabled?: boolean,
   enableBarCollapsing?: boolean,
   ephemeralWebSession?: boolean,
-  formSheetContentSize?: { width: number, height: number },
+  formSheetPreferredContentSize?: { width: number, height: number },
 |};
 
 export type InAppBrowserAndroidOptions = {|


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Unable to define the size of `formSheet` modals on iPad

## What is the new behavior?
Added new prop to allow for custom sized formSheet modals on iPad. 

Implements #330.

Migration steps:
- No migration steos needed, new prop is optional. 

## Screenshots

https://user-images.githubusercontent.com/18077159/156228925-e75433d2-4a04-4a45-9f31-1fedcf6421f8.mov


https://user-images.githubusercontent.com/18077159/156228944-e5a6ce5c-0357-4920-9dbf-0d44935fc17b.mov


