### PR TITLE
Remove QUERY_ALL_PACKAGES permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
           package="com.proyecto26.inappbrowser">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application>
         <activity


### PR DESCRIPTION
## What is the current behavior?
All apps that are using `react-native-inappbrowser` dependency automatically include the dangerous `QUERY_ALL_PACKAGES` permission and [need to explain](https://support.google.com/googleplay/android-developer/answer/10158779?hl=en#zippy=%2Cpermitted-uses-of-the-query-all-packages-permission) why they are using it or the apps will be removed from July 2022. 

## What is the new behavior?
We can safely remove this permission, as we only need to query the browsers that support custom tabs and having 
```
        <intent>
            <action android:name="android.support.customtabs.action.CustomTabsService" />
        </intent>
```
is enough for that.

See https://developer.android.com/training/package-visibility/use-cases#open-urls-custom-tabs
> However, you might want to [check whether the device has a browser that supports Custom Tabs](https://developers.google.com/web/android/custom-tabs/implementation-guide#opening_a_custom_tab), or select a specific browser to launch with Custom Tabs using [CustomTabsClient.getPackageName()](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#getPackageName(android.content.Context,%2520java.util.List%3Cjava.lang.String%3E)). In those cases, include the following <intent> element as part of the <queries> element in your manifest.

Fixes #311 

