### PR TITLE
Upgrade build configuration to use sdk 31 instead

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,10 +21,10 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
+def DEFAULT_COMPILE_SDK_VERSION = 31
+def DEFAULT_BUILD_TOOLS_VERSION = "31.0.0"
 def DEFAULT_MIN_SDK_VERSION = 16
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_TARGET_SDK_VERSION = 31
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
 
     <application>
         <activity
-        android:name=".ChromeTabsManagerActivity">
+        android:name=".ChromeTabsManagerActivity"
+        android:exported="false">
         </activity>
     </application>
     <queries>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
+        android:exported="true"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "31.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "21.4.7075529"
         androidXAnnotation = "1.2.0"
         androidXBrowser = "1.3.0"
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.2.2")
+        classpath("com.android.tools.build:gradle:7.0.0")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes  #327.

Upgrade example and the library project to compile with Sdk version 31 (Android 12). This also added required `exported` flag in `AndroidManifest.xml`. I believe there's no reason for external apps to open `ChromeTabsManagerActivity`, so the `exported` flag here should be `false`.

BREAKING CHANGES: By default, it will now use Android 31, so the library user have to upgrade if they don't provide required gradle ext values. I believe this won't impact much since most react native project already specify those sdk versions. Or they could also use override version in `AndroidManifest.xml`

```xml
<uses-sdk android:targetSdkVersion="{VERSION}"
 tools:overrideLibrary="com.proyecto26.inappbrowser"/>
```