### PR TITLE
[Android] Add includeReferrer to allow adding android package name as referrer for website to track

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Property       | Description
 `hasBackButton` (Boolean)         | Sets a back arrow instead of the default `X` icon to close the custom tab. [`true`/`false`]
 `browserPackage` (String)         | Package name of a browser to be used to handle Custom Tabs.
 `showInRecents` (Boolean)         | Determining whether browsed website should be shown as separate entry in Android recents/multitasking view. [`true`/`false`]
+`includeReferrer` (Boolean)         | Determining whether to include your package name as referrer for the website to track. [`true`/`false`]
 
 ### Demo
 

--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -1,7 +1,7 @@
 package com.proyecto26.inappbrowser;
 
-import android.R.anim;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.app.Activity;
@@ -31,7 +31,6 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.List;
-
 public class RNInAppBrowser {
   private final static String ERROR_CODE = "InAppBrowser";
   private static final String KEY_TOOLBAR_COLOR = "toolbarColor";
@@ -51,6 +50,7 @@ public class RNInAppBrowser {
   private static final String KEY_HAS_BACK_BUTTON = "hasBackButton";
   private static final String KEY_BROWSER_PACKAGE = "browserPackage";
   private static final String KEY_SHOW_IN_RECENTS = "showInRecents";
+  private static final String KEY_INCLUDE_REFERRER = "includeReferrer";
 
   private static final String ACTION_CUSTOM_TABS_CONNECTION = "android.support.customtabs.action.CustomTabsService";
   private static final String CHROME_PACKAGE_STABLE = "com.android.chrome";
@@ -181,13 +181,19 @@ public class RNInAppBrowser {
     }
 
     registerEventBus();
-    
+
     intent.setData(Uri.parse(url));
     if (options.hasKey(KEY_SHOW_PAGE_TITLE)) {
       builder.setShowTitle(options.getBoolean(KEY_SHOW_PAGE_TITLE));
     }
     else {
       intent.putExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.NO_TITLE);
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && options.hasKey(KEY_INCLUDE_REFERRER)
+        && options.getBoolean(KEY_INCLUDE_REFERRER)) {
+      intent.putExtra(Intent.EXTRA_REFERRER,
+          Uri.parse("android-app://" + context.getApplicationContext().getPackageName()));
     }
 
     currentActivity.startActivity(

--- a/example/utils.js
+++ b/example/utils.js
@@ -43,6 +43,7 @@ export const openLink = async (url, statusBarStyle, animated = true) => {
         hasBackButton: true,
         browserPackage: null,
         showInRecents: false,
+        includeReferrer: true,
       });
       // A delay to show an alert when the browser is closed
       await sleep(800);

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,7 @@ declare module 'react-native-inappbrowser-reborn' {
     hasBackButton?: boolean,
     browserPackage?: string,
     showInRecents?: boolean
+    includeReferrer?: boolean,
   }
 
   export type InAppBrowserOptions = InAppBrowserAndroidOptions | InAppBrowseriOSOptions;

--- a/types.js
+++ b/types.js
@@ -62,6 +62,7 @@ export type InAppBrowserAndroidOptions = {|
   hasBackButton?: boolean,
   browserPackage?: string,
   showInRecents?: boolean,
+  includeReferrer?: boolean,
 |};
 
 export type InAppBrowserOptions = {


### PR DESCRIPTION
## What is the current behavior?

There is no way to add referrer intent extra in android.

## What is the new behavior?

Added `includeReferrer` options for Android to add your package name as referrer when launching in in app browser:

See: https://developer.chrome.com/docs/android/custom-tabs/best-practices/#add-your-app-as-the-referrer

Fixes #86 