### PR TITLE
🔨Upgraded dependency org.greenrobot:eventbus to 3.1.0 due to build issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ repositories {
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation 'com.facebook.react:react-native:+'
-  implementation 'org.greenrobot:eventbus:3.+'
+  implementation 'org.greenrobot:eventbus:3.1.0'
   def supportLibVersion = safeExtGet('supportLibVersion', safeExtGet('supportVersion', null))
   def androidXVersion = safeExtGet('androidXVersion', null)
   if (supportLibVersion && androidXVersion == null) {


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

## What is the current behavior?
App won't compile.

## What is the new behavior?
Bumped org.greenrobot:eventbus dependency causing issues since JCenter is deprecated.

`implementation 'org.greenrobot:eventbus:3.+'` to `implementation 'org.greenrobot:eventbus:3.1.0'`

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

