### PR TITLE
:wrench: Upgraded dependency org.greenrobot:eventbus to 3.3.1 due to …

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ repositories {
 dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation 'com.facebook.react:react-native:+'
-  implementation 'org.greenrobot:eventbus:3.1.0'
+  implementation 'org.greenrobot:eventbus:3.3.1'
   def supportLibVersion = safeExtGet('supportLibVersion', safeExtGet('supportVersion', null))
   def androidXVersion = safeExtGet('androidXVersion', null)
   if (supportLibVersion && androidXVersion == null) {


### PR DESCRIPTION
…build issue

<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [X] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
App won't compile.

## What is the new behavior?
<!-- Describe the changes. -->
Bumped org.greenrobot:eventbus dependency causing issues since JCenter is deprecated.

implementation 'org.greenrobot:eventbus:3.1.0' to implementation 'org.greenrobot:eventbus:3.3.1'

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

