### PR TITLE
fix androidXVersion to prevent build fails

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation "com.android.support:support-annotations:$supportLibVersion"
     implementation "com.android.support:customtabs:$supportLibVersion"
   } else {
-    def defaultAndroidXVersion = "1.+"
+    def defaultAndroidXVersion = "1.5.+"
     if (androidXVersion == null) {
       androidXVersion = defaultAndroidXVersion
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,17 +53,22 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation 'org.greenrobot:eventbus:3.1.0'
   def supportLibVersion = safeExtGet('supportLibVersion', safeExtGet('supportVersion', null))
-  def androidXVersion = safeExtGet('androidXVersion', null)
-  if (supportLibVersion && androidXVersion == null) {
+  def androidXAnnotationVersion = safeExtGet('androidXAnnotationVersion', null)
+  def androidXBrowserVersion = safeExtGet('androidXBrowserVersion', null)
+  if (supportLibVersion) {
     implementation "com.android.support:support-annotations:$supportLibVersion"
     implementation "com.android.support:customtabs:$supportLibVersion"
   } else {
-    def defaultAndroidXVersion = "1.5.+"
-    if (androidXVersion == null) {
-      androidXVersion = defaultAndroidXVersion
+    def defaultAndroidXAnnotationVersion = "1.5.+"
+    def defaultAndroidXBrowserVersion = "1.4.+"
+    if (androidXAnnotationVersion == null) {
+      androidXAnnotationVersion = defaultAndroidXAnnotationVersion
     }
-    def androidXAnnotation = safeExtGet('androidXAnnotation', androidXVersion)
-    def androidXBrowser = safeExtGet('androidXBrowser', androidXVersion)
+    if (androidXBrowserVersion == null) {
+      androidXBrowserVersion = defaultAndroidXBrowserVersion
+    }
+    def androidXAnnotation = safeExtGet('androidXAnnotation', androidXAnnotationVersion)
+    def androidXBrowser = safeExtGet('androidXBrowser', androidXBrowserVersion)
     implementation "androidx.annotation:annotation:$androidXAnnotation"
     implementation "androidx.browser:browser:$androidXBrowser"
   }


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The investigation is available here: https://github.com/proyecto26/react-native-inappbrowser/issues/398

This exact problem was already addressed multiple times and we still get surprised by failing builds (#298, #386 ). I think it's worth to set a fixed version to prevent this kind of surprise in the future. 🙏

## What is the new behavior?
<!-- Describe the changes. -->
Fixes androidXVersion to 1.5.+ which is the latest before the kotlin 1.8.0 issue...

Fixes/Implements/Closes #398.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

