### PR TITLE
Add error description to openAuth response

### DIFF
--- a/ios/RNInAppBrowser.m
+++ b/ios/RNInAppBrowser.m
@@ -82,9 +82,18 @@ RCT_EXPORT_METHOD(openAuth:(NSString *)authURL
             @"url" : url,
           });
         } else {
-          redirectResolve(@{
-            @"type" : @"cancel",
-          });
+          NSDictionary *userInfo = [error userInfo];
+          NSString *errorDescription = [userInfo objectForKey:NSDebugDescriptionErrorKey];
+          if (errorDescription != nil) {
+            redirectResolve(@{
+              @"type" : @"cancel",
+              @"description" : errorDescription,
+            });
+          } else {
+            redirectResolve(@{
+              @"type" : @"cancel",
+            });
+          }
         }
         [strongSelf flowDidFinish];
       }


### PR DESCRIPTION
Currently there is no way to distiguish between user canceled and canceled from an error.  Adding the error description allows for a better user experience.

<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently when openAuth is terminated by error or by the user hitting cancel, the result is the same and type: cancel is returned
Example - {"type":"cancel"}

## What is the new behavior?
<!-- Describe the changes. -->
This change simply adds the error description if it exists so a better user experience can be achieved.
Example - {"type":"cancel","description":"The UIWindowScene for the returned window was not in the foreground active state."}

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

