### PR TITLE
feat(android): 🌟 add support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 31
 
 android {
+  namespace = "com.proyecto26.inappbrowser"
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
   buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
   defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.proyecto26.inappbrowser">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application>
-        <activity
-        android:name=".ChromeTabsManagerActivity"
-        android:exported="false">
+        <activity android:name=".ChromeTabsManagerActivity"
+            android:exported="false">
         </activity>
     </application>
     <queries>


### PR DESCRIPTION
# Overview
Starting from React Native v0.73 , all libraries will need to be updated with namespace due to the upgrade to AGP 8
https://github.com/react-native-community/discussions-and-proposals/issues/671

OS | Implemented
-- | --
iOS | ❌
Android | ✅

# Test Plan
I tested the changes on RN 0.71.11 and everything works!

___
Sorry I did not use the default template. I felt that the default template does not apply to this, I'll follow the template if required!
