### PR TITLE
fix: persist default settings

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -102,15 +102,18 @@ async function checkResultAndReturnUrl(
 
 export async function openBrowserAsync(
   url: string,
-  options?: InAppBrowserOptions = {
+  options?: InAppBrowserOptions = {}
+): Promise<BrowserResult> {
+  const defaults = {
     animated: true,
     modalEnabled: true,
     dismissButtonStyle: 'close',
     readerMode: false,
     enableBarCollapsing: false,
-  }
-): Promise<BrowserResult> {
+  };
+
   return RNInAppBrowser.open({
+    ...defaults,
     ...options,
     url,
     preferredBarTintColor:


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Opening an In App Browser with any configuration completely negates the defaults even if they are not overloaded.

## What is the new behavior?
<!-- Describe the changes. -->
Opening an In App Browser now persists the defaults if they are not overloaded.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

