### PR TITLE
fixed  share icon display issue on android

### DIFF
--- a/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
+++ b/android/src/main/java/com/proyecto26/inappbrowser/RNInAppBrowser.java
@@ -133,10 +133,16 @@ public class RNInAppBrowser {
     setColor(builder, options, KEY_NAVIGATION_BAR_COLOR, "setNavigationBarColor", "navigation bar");
     setColor(builder, options, KEY_NAVIGATION_BAR_DIVIDER_COLOR, "setNavigationBarDividerColor", "navigation bar divider");
 
-    if (options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM) && 
-        options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)) {
-      builder.addDefaultShareMenuItem();
+    if(options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM)){
+      if(options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)){
+        builder.setShareState(CustomTabsIntent.SHARE_STATE_ON);
+      }else{
+        builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF);
+      }
+    }else{
+      builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF);
     }
+    
     if (options.hasKey(KEY_ANIMATIONS)) {
       final ReadableMap animations = options.getMap(KEY_ANIMATIONS);
       applyAnimation(context, builder, animations);


### PR DESCRIPTION
<!--
We, the rest of the React Native community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/proyecto26/react-native-inappbrowser/blob/main/CONTRIBUTING.md#pull-request-process.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
enableDefaultShare: false is not working on android

## What is the new behavior?
enableDefaultShare: false is now working on android

Fixes/Implements/Closes #[Issue Number].

Replaced the native library code in RNInAppBrowser.java

from
 ```
    if (options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM) && 
        options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)) {
      builder.addDefaultShareMenuItem();
    }
    ```

to
if(options.hasKey(KEY_DEFAULT_SHARE_MENU_ITEM)){
  if(options.getBoolean(KEY_DEFAULT_SHARE_MENU_ITEM)){
    builder.setShareState(CustomTabsIntent.SHARE_STATE_ON);
  }else{
    builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF);
  }
}else{
  builder.setShareState(CustomTabsIntent.SHARE_STATE_OFF);
}
```
